### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 license = "ISC"
 description = "AI platform agnostic cli"
-homepage = "https://github.com/MNThomson/chat"
+repository = "https://github.com/MNThomson/chat"
 
 [lib]
 name = "chat"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).